### PR TITLE
Feat/seedboxkeys

### DIFF
--- a/src/Sodium.Core/PublicKeyBox.cs
+++ b/src/Sodium.Core/PublicKeyBox.cs
@@ -42,6 +42,26 @@ namespace Sodium
       return new KeyPair(publicKey, privateKey);
     }
 
+    /// <summary>Creates a new key pair based on the provided seed.</summary>
+    /// <param name="seed">Seed data.</param>
+    /// <returns>A KeyPair.</returns>
+    /// <exception cref="SeedOutOfRangeException"></exception>
+    public static KeyPair GenerateSeededKeyPair(byte[] seed)
+    {
+      var publicKey = new byte[PublicKeyBytes];
+      var privateKey = new byte[SecretKeyBytes];
+      // Expected length of the keypair seed
+      int seedBytes = SodiumLibrary.crypto_box_seedbytes();
+      //validate the length of the seed
+      if (seed == null || seed.Length != seedBytes)
+        throw new SeedOutOfRangeException("seed", (seed == null) ? 0 : seed.Length,
+          string.Format("Key seed must be {0} bytes in length.", SecretKeyBytes));
+      
+      SodiumLibrary.crypto_box_seed_keypair(publicKey, privateKey, seed);
+
+      return new KeyPair(publicKey, privateKey);
+    }
+
     /// <summary>Generates a random 24 byte nonce.</summary>
     /// <returns>Returns a byte array with 24 random bytes</returns>
     public static byte[] GenerateNonce()

--- a/src/Sodium.Core/PublicKeyBox.cs
+++ b/src/Sodium.Core/PublicKeyBox.cs
@@ -42,26 +42,6 @@ namespace Sodium
       return new KeyPair(publicKey, privateKey);
     }
 
-    /// <summary>Creates a new key pair based on the provided seed.</summary>
-    /// <param name="seed">Seed data.</param>
-    /// <returns>A KeyPair.</returns>
-    /// <exception cref="SeedOutOfRangeException"></exception>
-    public static KeyPair GenerateSeededKeyPair(byte[] seed)
-    {
-      var publicKey = new byte[PublicKeyBytes];
-      var privateKey = new byte[SecretKeyBytes];
-      // Expected length of the keypair seed
-      int seedBytes = SodiumLibrary.crypto_box_seedbytes();
-      //validate the length of the seed
-      if (seed == null || seed.Length != seedBytes)
-        throw new SeedOutOfRangeException("seed", (seed == null) ? 0 : seed.Length,
-          string.Format("Key seed must be {0} bytes in length.", SecretKeyBytes));
-      
-      SodiumLibrary.crypto_box_seed_keypair(publicKey, privateKey, seed);
-
-      return new KeyPair(publicKey, privateKey);
-    }
-
     /// <summary>Generates a random 24 byte nonce.</summary>
     /// <returns>Returns a byte array with 24 random bytes</returns>
     public static byte[] GenerateNonce()

--- a/src/Sodium.Core/SodiumLibrary.cs
+++ b/src/Sodium.Core/SodiumLibrary.cs
@@ -128,10 +128,6 @@ namespace Sodium
     [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_box_keypair(byte[] publicKey, byte[] secretKey);
 
-    //crypto_box_seed_keypair
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
-    internal static extern int crypto_box_seed_keypair(byte[] publicKey, byte[] secretKey, byte[] seed);
-
     //crypto_box_easy
     [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_box_easy(byte[] buffer, byte[] message, long messageLength, byte[] nonce, byte[] publicKey, byte[] secretKey);
@@ -147,10 +143,6 @@ namespace Sodium
     //crypto_box_open_detached
     [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_box_open_detached(byte[] buffer, byte[] cipherText, byte[] mac, long cipherTextLength, byte[] nonce, byte[] pk, byte[] sk);
-
-    //crypto_box_seedbytes
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
-    internal static extern int crypto_box_seedbytes();
 
     //crypto_scalarmult_bytes
     [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]

--- a/src/Sodium.Core/SodiumLibrary.cs
+++ b/src/Sodium.Core/SodiumLibrary.cs
@@ -128,6 +128,10 @@ namespace Sodium
     [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_box_keypair(byte[] publicKey, byte[] secretKey);
 
+    //crypto_box_seed_keypair
+    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int crypto_box_seed_keypair(byte[] publicKey, byte[] secretKey, byte[] seed);
+
     //crypto_box_easy
     [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_box_easy(byte[] buffer, byte[] message, long messageLength, byte[] nonce, byte[] publicKey, byte[] secretKey);
@@ -143,6 +147,10 @@ namespace Sodium
     //crypto_box_open_detached
     [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_box_open_detached(byte[] buffer, byte[] cipherText, byte[] mac, long cipherTextLength, byte[] nonce, byte[] pk, byte[] sk);
+
+    //crypto_box_seedbytes
+    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    internal static extern int crypto_box_seedbytes();
 
     //crypto_scalarmult_bytes
     [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]

--- a/test/Sodium.Tests/PublicKeyBoxExceptionTest.cs
+++ b/test/Sodium.Tests/PublicKeyBoxExceptionTest.cs
@@ -25,6 +25,20 @@ namespace Tests
     }
 
     [Test]
+    public void GenerateKeyPairFromPrivateBadSeedTest()
+    {
+      //30 byte
+      var invalidSeed = new byte[] {
+        0x5d,0xab,0x08,0x7e,0x62,0x4a,0x8a,0x4b,
+        0x79,0xe1,0x7f,0x8b,0x83,0x80,0x0e,0xe6,
+        0x6f,0x3b,0xb1,0x29,0x26,0x18,0xb6,0xfd,
+        0x1c,0x2f,0x8b,0x27,0xff,0x88
+      };
+      Assert.Throws<SeedOutOfRangeException>(
+        () => PublicKeyBox.GenerateSeededKeyPair(invalidSeed));
+    }
+
+    [Test]
     public void PublicKeyBoxCreateWithBadPrivateKey()
     {
       var bobSk = new byte[] {

--- a/test/Sodium.Tests/PublicKeyBoxTest.cs
+++ b/test/Sodium.Tests/PublicKeyBoxTest.cs
@@ -45,6 +45,24 @@ namespace Tests
       CollectionAssert.AreEqual(Utilities.HexToBinary("753cb95919b15b76654b1969c554a4aaf8334402ef1468cb40a602b9c9fd2c13"), actual.PublicKey);
     }
 
+    /// <summary>Does PublicKeyBox.GenerateSeededKeyPair(seed) return the rigt deterministic public key</summary>
+    [Test]
+    public void GenerateDeterministicPublicKeyFromSeedTest()
+    {
+      var actual = PublicKeyBox.GenerateSeededKeyPair(Utilities.HexToBinary("0b93e7914224f0e7de0984ce6480020e7f11c37c35e967399625b6186202275c"));
+      
+      CollectionAssert.AreEqual( Utilities.HexToBinary("309db6bd8e8fc75d0beda31c8273d572541784f1d566f877aeedda5c4cb87514"), actual.PublicKey);
+    }
+
+    /// <summary>Does PublicKeyBox.GenerateSeededKeyPair(seed) return the rigt deterministic private key</summary>
+    [Test]
+    public void GenerateDeterministicPrivateKeyFromSeedTest()
+    {
+      var actual = PublicKeyBox.GenerateSeededKeyPair(Utilities.HexToBinary("0b93e7914224f0e7de0984ce6480020e7f11c37c35e967399625b6186202275c"));
+
+      CollectionAssert.AreEqual(Utilities.HexToBinary("082f8b811ca316a1fa22d40a19c7cba91a814d73a333c752d508efd3be2d58db"), actual.PrivateKey);
+    }
+
     /// <summary>Does PublicKeyBox.Create creates the right data?</summary>
     [Test]
     public void SimpleCreateTest()


### PR DESCRIPTION
Adding the ability to create a box key pair using a seed. Tests ensure the public and private keys generated are deterministic with respect to the seed. Invalid test uses an invalid length seed. 