### PR TITLE
Publish a .NET Standard 2.0 version

### DIFF
--- a/src/Sodium.Core/Sodium.Core.csproj
+++ b/src/Sodium.Core/Sodium.Core.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
     <Description>libsodium for .net core</Description>
     <Copyright>Copyright © tabrath 2017</Copyright>
     <AssemblyTitle>Sodium.Core</AssemblyTitle>


### PR DESCRIPTION
Addressing #20  :
Publish a .NET Standard 2.0 version of the Nuget.
When using form a project targeted to .NET Frameweok, this will help avoid getting all dependencies of NETStandard.Library.