### PR TITLE
Add Xamarin implementation

### DIFF
--- a/Contributors.md
+++ b/Contributors.md
@@ -9,3 +9,4 @@ Those listed below have contributed to `libsodium-net` or `libsodium-core`, and 
  * Trond Arne Bråthen <tabrath@gmail.com>
  * Daniel (danielcrenna) <daniel.crenna@gmail.com>
  * PauliusK (Nithilim) <https://github.com/Nithilim>
+ * Jonas Schmid <https://github.com/jschmid>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ libsodium-net is not compliant with .net standard, so this is just a migrated fo
 
     dotnet add package Sodium.Core
 
+To use the library with Xamarin, you have to follow additional steps described here: [Xamarin documentation](Xamarin.md).
+
 ## Documentation
 
 [libsodium-net](http://bitbeans.gitbooks.io/libsodium-net/content/) documentation is available (an adapted copy of the [original](http://doc.libsodium.org/) written by Frank Denis ([@jedisct1](https://github.com/jedisct1))).

--- a/Xamarin.md
+++ b/Xamarin.md
@@ -1,0 +1,95 @@
+# Using Sodium.Core with Xamarin
+
+## NuGet package
+
+Install the [Sodium.Core](https://www.nuget.org/packages/Sodium.Core/) NuGet package in your Xamarin core project.
+
+## Compile the native libraries
+
+Installing the NuGet is not enough. You will have to compile the libsodium library for iOS and Android yourself, because they are not provided out of the box.
+
+*The following instructions have been tested on Mac OS 10.14, using libsodium 1.0.18 and the [installation](https://download.libsodium.org/doc/installation) documentation.*
+
+[Download the latest stable version](https://download.libsodium.org/libsodium/releases/) (for example `libsodium-1.0.18-stable.tar.gz`) and untar it:
+
+```bash
+tar xzf libsodium-1.0.18-stable.tar.gz
+cd libsodium-stable
+```
+
+Then run the commands:
+
+```bash
+./configure
+make && make check
+sudo make install
+```
+
+Make sure everything went fine.
+
+### Compile and install on iOS
+
+First, make sure that you have the Xcode Command Line Tools properly installed and configured. Run:
+
+```bash
+xcode-select -p
+```
+
+It should return something of the form `/Applications/Xcode.app/Contents/Developer`.
+
+If it doesn't, run
+
+```bash
+sudo xcode-select -s /Applications/Xcode.app
+```
+
+*note*: `/Applications/Xcode.app` is the path to your Xcode installation.
+
+Then, run the command:
+
+```bash
+LIBSODIUM_FULL_BUILD=true dist-build/ios.sh
+```
+
+This will create the library in `libsodium-ios/lib/libsodium.a`.
+
+In Visual Studio - in the Xamarin.iOS project - add this new file in your project. Make sure that the *Build Action* of the file is *None*. Right-click in the iOS project and do  "Add > Add Native Reference". Select the file you have just added.
+
+### Compile and install on Android
+
+First, make sure that you have installed the [Android NDK](https://developer.android.com/ndk/), and that you have the `ANDROID_NDK_HOME` environment variable. For example using:
+
+```bash
+export ANDROID_NDK_HOME=/Users/john/Library/Android/sdk/ndk/20.0.5594570
+```
+
+Then run the commands:
+
+```bash
+dist-build/android-x86.sh
+dist-build/android-x86_64.sh
+dist-build/android-armv7-a.sh
+dist-build/android-armv8-a.sh
+```
+
+This will create 4 new folders that each contain the *libsodium.so* file. Beware of using the **.so** file and not the **.a** file like you did for iOS.
+
+In you Xamarin.Android project create a new folder `Resources/lib/`. Inside, create 4 new folders called `x86`, `x86_64`, `armeabi-v7a` and `arm64-v8a`. Inside those folders add the *libsodium.so* files following the mapping:
+
+| libsodium folder           | Xamarin.Android folder |
+| -------------------------- | ---------------------- |
+| libsodium-android-i686     | x86                    |
+| libsodium-android-westmere | x86_64                 |
+| libsodium-android-armv7-a  | armeabi-v7a            |
+| libsodium-android-armv8-a  | arm64-v8a              |
+
+Change the *Build Action* of the files to *AndroidNativeLibrary*.
+
+## Usage
+
+You can now use libsodium inside your Xamarin code, by including the package `Sodium`. For example:
+
+```csharp
+var version = Sodium.SodiumCore.SodiumVersionString();
+Console.WriteLine($"Libsodium version: {version}");
+```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,22 +41,21 @@ build_script:
   - ps: |
       if ($env:APPVEYOR_REPO_BRANCH -eq "master")
       {
-        dotnet build "src\Sodium.Core" -c $env:CONFIGURATION
+        msbuild /t:build "src\Sodium.Core" /p:Configuration=$env:CONFIGURATION
       }
       else
       {
-        dotnet build "src\Sodium.Core" -c $env:CONFIGURATION --version-suffix $env:VERSION_SUFFIX
+        msbuild /t:build "src\Sodium.Core" /p:Configuration=$env:CONFIGURATION /p:version-suffix=$env:VERSION_SUFFIX
       }
-
 after_build:
   - ps: |
       if ($env:APPVEYOR_REPO_BRANCH -eq "master")
       {
-        dotnet pack "src\Sodium.Core" -c $env:CONFIGURATION --no-build -o $env:APPVEYOR_BUILD_FOLDER\artifacts
+        msbuild /t:pack "src\Sodium.Core" /p:Configuration=$env:CONFIGURATION /p:NoBuild=true /p:PackageOutputPath=$env:APPVEYOR_BUILD_FOLDER\artifacts
       }
       else
       {
-        dotnet pack "src\Sodium.Core" -c $env:CONFIGURATION --no-build --version-suffix $env:VERSION_SUFFIX -o $env:APPVEYOR_BUILD_FOLDER\artifacts
+        msbuild /t:pack "src\Sodium.Core" /p:Configuration=$env:CONFIGURATION /p:NoBuild=true /p:version-suffix=$env:VERSION_SUFFIX /p:PackageOutputPath=$env:APPVEYOR_BUILD_FOLDER\artifacts
       }
 
 test: off

--- a/src/Sodium.Core/Sodium.Core.csproj
+++ b/src/Sodium.Core/Sodium.Core.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="MSBuild.Sdk.Extras/2.0.54">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard1.6;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>MonoAndroid90;Xamarin.iOS10;netstandard1.6;netstandard2.0</TargetFrameworks>
     <Description>libsodium for .net core</Description>
     <Copyright>Copyright © tabrath 2019</Copyright>
     <AssemblyTitle>Sodium.Core</AssemblyTitle>
@@ -10,7 +10,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <AssemblyName>Sodium.Core</AssemblyName>
     <PackageId>Sodium.Core</PackageId>
-    <PackageTags>libsodium</PackageTags>
+    <PackageTags>libsodium;xamarin;xamarin.ios;xamarin.android</PackageTags>
     <PackageLicenseUrl>https://github.com/tabrath/libsodium-core/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryType>git</RepositoryType>
     <RepositoryUrl>https://github.com/tabrath/libsodium-core/</RepositoryUrl>
@@ -34,6 +34,13 @@
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <DefineConstants>$(DefineConstants)</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('Xamarin.iOS'))">
+    <DefineConstants>$(DefineConstants);IOS</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
+    <DefineConstants>$(DefineConstants);ANDROID</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Sodium.Core/SodiumLibrary.cs
+++ b/src/Sodium.Core/SodiumLibrary.cs
@@ -8,296 +8,303 @@ namespace Sodium
   /// </summary>
   public static partial class SodiumLibrary
   {
+
+#if IOS
+    const string DllName = "__Internal";
+#else
+    const string DllName = "libsodium";
+#endif
+
     //sodium_init
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern void sodium_init();
 
     //randombytes_buf
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern void randombytes_buf(byte[] buffer, int size);
 
     //randombytes_uniform
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int randombytes_uniform(int upperBound);
 
     //sodium_increment
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern void sodium_increment(byte[] buffer, long length);
 
     //sodium_compare
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int sodium_compare(byte[] a, byte[] b, long length);
 
     //sodium_version_string
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern IntPtr sodium_version_string();
 
     //crypto_hash
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_hash(byte[] buffer, byte[] message, long length);
 
     //crypto_hash_sha512
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_hash_sha512(byte[] buffer, byte[] message, long length);
 
     //crypto_hash_sha256
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_hash_sha256(byte[] buffer, byte[] message, long length);
 
     //crypto_generichash
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_generichash(byte[] buffer, int bufferLength, byte[] message, long messageLength, byte[] key, int keyLength);
 
     //crypto_generichash_blake2b_salt_personal
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_generichash_blake2b_salt_personal(byte[] buffer, int bufferLength, byte[] message, long messageLength, byte[] key, int keyLength, byte[] salt, byte[] personal);
 
     //crypto_onetimeauth
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_onetimeauth(byte[] buffer, byte[] message, long messageLength, byte[] key);
 
     //crypto_onetimeauth_verify
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_onetimeauth_verify(byte[] signature, byte[] message, long messageLength, byte[] key);
 
     //crypto_pwhash_str
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_pwhash_str(byte[] buffer, byte[] password, long passwordLen, long opsLimit, int memLimit);
 
     //crypto_pwhash_str_verify
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_pwhash_str_verify(byte[] buffer, byte[] password, long passLength);
 
     //crypto_pwhash
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_pwhash(byte[] buffer, long bufferLen, byte[] password, long passwordLen, byte[] salt, long opsLimit, int memLimit, int alg);
 
     //crypto_pwhash_scryptsalsa208sha256_str
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_pwhash_scryptsalsa208sha256_str(byte[] buffer, byte[] password, long passwordLen, long opsLimit, int memLimit);
 
     //crypto_pwhash_scryptsalsa208sha256
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_pwhash_scryptsalsa208sha256(byte[] buffer, long bufferLen, byte[] password, long passwordLen, byte[] salt, long opsLimit, int memLimit);
 
     //crypto_pwhash_scryptsalsa208sha256_str_verify
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_pwhash_scryptsalsa208sha256_str_verify(byte[] buffer, byte[] password, long passLength);
 
     //crypto_sign_keypair
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_sign_keypair(byte[] publicKey, byte[] secretKey);
 
     //crypto_sign_seed_keypair
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_sign_seed_keypair(byte[] publicKey, byte[] secretKey, byte[] seed);
 
     //crypto_sign
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_sign(byte[] buffer, ref long bufferLength, byte[] message, long messageLength, byte[] key);
 
     //crypto_sign_open
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_sign_open(byte[] buffer, ref long bufferLength, byte[] signedMessage, long signedMessageLength, byte[] key);
 
     //crypto_sign_detached
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_sign_detached(byte[] signature, ref long signatureLength, byte[] message, long messageLength, byte[] key);
 
     //crypto_sign_verify_detached
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_sign_verify_detached(byte[] signature, byte[] message, long messageLength, byte[] key);
 
     //crypto_sign_ed25519_sk_to_seed
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_sign_ed25519_sk_to_seed(byte[] seed, byte[] secretKey);
 
     //crypto_sign_ed25519_sk_to_pk
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_sign_ed25519_sk_to_pk(byte[] publicKey, byte[] secretKey);
 
     //crypto_sign_ed25519_pk_to_curve25519
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_sign_ed25519_pk_to_curve25519(byte[] curve25519Pk, byte[] ed25519Pk);
 
     //crypto_sign_ed25519_sk_to_curve25519
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_sign_ed25519_sk_to_curve25519(byte[] curve25519Sk, byte[] ed25519Sk);
 
     //crypto_box_keypair
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_box_keypair(byte[] publicKey, byte[] secretKey);
 
     //crypto_box_seed_keypair
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_box_seed_keypair(byte[] publicKey, byte[] secretKey, byte[] seed);
 
     //crypto_box_easy
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_box_easy(byte[] buffer, byte[] message, long messageLength, byte[] nonce, byte[] publicKey, byte[] secretKey);
 
     //crypto_box_open_easy
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_box_detached(byte[] cipher, byte[] mac, byte[] message, long messageLength, byte[] nonce, byte[] pk, byte[] sk);
 
     //crypto_box_detached
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_box_open_easy(byte[] buffer, byte[] cipherText, long cipherTextLength, byte[] nonce, byte[] publicKey, byte[] secretKey);
 
     //crypto_box_open_detached
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_box_open_detached(byte[] buffer, byte[] cipherText, byte[] mac, long cipherTextLength, byte[] nonce, byte[] pk, byte[] sk);
 
     //crypto_box_seedbytes
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_box_seedbytes();
 
     //crypto_scalarmult_bytes
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_scalarmult_bytes();
 
     //crypto_scalarmult_scalarbytes
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_scalarmult_scalarbytes();
 
     //crypto_scalarmult_primitive
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern byte crypto_scalarmult_primitive();
 
     //crypto_scalarmult_base
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_scalarmult_base(byte[] q, byte[] n);
 
     //crypto_scalarmult
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_scalarmult(byte[] q, byte[] n, byte[] p);
 
     //crypto_box_seal
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_box_seal(byte[] buffer, byte[] message, long messageLength, byte[] pk);
 
     //crypto_box_seal_open
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_box_seal_open(byte[] buffer, byte[] cipherText, long cipherTextLength, byte[] pk, byte[] sk);
 
     //crypto_secretbox_easy
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_secretbox_easy(byte[] buffer, byte[] message, long messageLength, byte[] nonce, byte[] key);
 
     //crypto_secretbox_open_easy
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_secretbox_open_easy(byte[] buffer, byte[] cipherText, long cipherTextLength, byte[] nonce, byte[] key);
 
     //crypto_secretbox_detached
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_secretbox_detached(byte[] cipher, byte[] mac, byte[] message, long messageLength, byte[] nonce, byte[] key);
 
     //crypto_secretbox_open_detached
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_secretbox_open_detached(byte[] buffer, byte[] cipherText, byte[] mac, long cipherTextLength, byte[] nonce, byte[] key);
 
     //crypto_auth
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_auth(byte[] buffer, byte[] message, long messageLength, byte[] key);
 
     //crypto_auth_verify
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_auth_verify(byte[] signature, byte[] message, long messageLength, byte[] key);
 
     //crypto_auth_hmacsha256
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_auth_hmacsha256(byte[] buffer, byte[] message, long messageLength, byte[] key);
 
     //crypto_auth_hmacsha256_verify
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_auth_hmacsha256_verify(byte[] signature, byte[] message, long messageLength, byte[] key);
 
     //crypto_auth_hmacsha512
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_auth_hmacsha512(byte[] signature, byte[] message, long messageLength, byte[] key);
 
     //crypto_auth_hmacsha512_verify
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_auth_hmacsha512_verify(byte[] signature, byte[] message, long messageLength, byte[] key);
 
     //crypto_shorthash
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_shorthash(byte[] buffer, byte[] message, long messageLength, byte[] key);
 
     //crypto_stream_xor
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_stream_xor(byte[] buffer, byte[] message, long messageLength, byte[] nonce, byte[] key);
 
     //crypto_stream_chacha20_xor
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_stream_chacha20_xor(byte[] buffer, byte[] message, long messageLength, byte[] nonce, byte[] key);
 
     //sodium_bin2hex
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern IntPtr sodium_bin2hex(byte[] hex, int hexMaxlen, byte[] bin, int binLen);
 
     //sodium_hex2bin
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int sodium_hex2bin(IntPtr bin, int binMaxlen, string hex, int hexLen, string ignore, out int binLen, string hexEnd);
 
     //sodium_bin2base64
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern IntPtr sodium_bin2base64(byte[] b64, int b64Maxlen, byte[] bin, int binLen, int variant);
 
     //sodium_base642bin
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int sodium_base642bin(IntPtr bin, int binMaxlen, string b64, int b64Len, string ignore, out int binLen, out char b64End, int variant);
 
     //sodium_base64_encoded_len
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int sodium_base64_encoded_len(int binLen, int variant);
 
     //crypto_aead_chacha20poly1305_ietf_encrypt
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_aead_chacha20poly1305_ietf_encrypt(IntPtr cipher, out long cipherLength, byte[] message, long messageLength, byte[] additionalData, long additionalDataLength, byte[] nsec, byte[] nonce, byte[] key);
 
     //crypto_aead_chacha20poly1305_ietf_decrypt
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_aead_chacha20poly1305_ietf_decrypt(IntPtr message, out long messageLength, byte[] nsec, byte[] cipher, long cipherLength, byte[] additionalData, long additionalDataLength, byte[] nonce, byte[] key);
 
     //crypto_aead_chacha20poly1305_encrypt
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_aead_chacha20poly1305_encrypt(IntPtr cipher, out long cipherLength, byte[] message, long messageLength, byte[] additionalData, long additionalDataLength, byte[] nsec, byte[] nonce, byte[] key);
 
     //crypto_aead_chacha20poly1305_decrypt
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_aead_chacha20poly1305_decrypt(IntPtr message, out long messageLength, byte[] nsec, byte[] cipher, long cipherLength, byte[] additionalData, long additionalDataLength, byte[] nonce, byte[] key);
 
     //crypto_aead_xchacha20poly1305_ietf_encrypt
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_aead_xchacha20poly1305_ietf_encrypt(IntPtr cipher, out long cipherLength, byte[] message, long messageLength, byte[] additionalData, long additionalDataLength, byte[] nsec, byte[] nonce, byte[] key);
 
     //crypto_aead_xchacha20poly1305_ietf_decrypt
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_aead_xchacha20poly1305_ietf_decrypt(IntPtr message, out long messageLength, byte[] nsec, byte[] cipher, long cipherLength, byte[] additionalData, long additionalDataLength, byte[] nonce, byte[] key);
 
     //crypto_aead_aes256gcm_is_available
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_aead_aes256gcm_is_available();
 
     //crypto_aead_aes256gcm_encrypt
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_aead_aes256gcm_encrypt(IntPtr cipher, out long cipherLength, byte[] message, long messageLength, byte[] additionalData, long additionalDataLength, byte[] nsec, byte[] nonce, byte[] key);
 
     //crypto_aead_aes256gcm_decrypt
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_aead_aes256gcm_decrypt(IntPtr message, out long messageLength, byte[] nsec, byte[] cipher, long cipherLength, byte[] additionalData, long additionalDataLength, byte[] nonce, byte[] key);
 
     //crypto_generichash_init
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_generichash_init(IntPtr state, byte[] key, int keySize, int hashSize);
 
     //crypto_generichash_update
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_generichash_update(IntPtr state, byte[] message, long messageLength);
 
     //crypto_generichash_final
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_generichash_final(IntPtr state, byte[] buffer, int bufferLength);
 
     //crypto_generichash_state
@@ -321,10 +328,10 @@ namespace Sodium
       public byte last_node;
     }
 
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_stream_xchacha20(byte[] buffer, int bufferLength, byte[] nonce, byte[] key);
 
-    [DllImport("libsodium", CallingConvention = CallingConvention.Cdecl)]
+    [DllImport(DllName, CallingConvention = CallingConvention.Cdecl)]
     internal static extern int crypto_stream_xchacha20_xor(byte[] buffer, byte[] message, long messageLength, byte[] nonce, byte[] key);
   }
 }


### PR DESCRIPTION
For a project using Xamarin, I had to integrate libsodium. I could not find readily available packages. 

There are minimal changes needed to make it work:

* Update the way `DllImport` is called, because of the way Xamarin.iOS packages dlls
* Use `msbuild` instead of `dotnet`, because dotnet does not support Xamarin

For now, the binary files for Android and iOS still have to be included manually to the project, because the `libsodium` Nuget itself does not contain them, but at least the "C# wrapper" part can be automated. 

Instead of publishing my own nuget under a different name, I though it would be nicer to submit a PR first to see what you thought about it.

The PR has to be improved a bit (squashing commits, updating the readme), but I'll wait for your feedback before spending more time on it.

What do you think ?