### PR TITLE
Don't use utf8

### DIFF
--- a/src/Sodium.Core/PasswordHash.cs
+++ b/src/Sodium.Core/PasswordHash.cs
@@ -253,7 +253,7 @@ namespace Sodium
                 throw new OutOfMemoryException("Internal error, hash failed (usually because the operating system refused to allocate the amount of requested memory).");
             }
 
-            return Utilities.UnsafeAsciiBytesToString(buffer, 0, buffer.Length);
+            return Utilities.UnsafeAsciiBytesToString(buffer);
         }
 
         /// <summary>Verifies that a hash generated with ArgonHashString matches the supplied password.</summary>
@@ -330,7 +330,7 @@ namespace Sodium
                 throw new OutOfMemoryException("Internal error, hash failed (usually because the operating system refused to allocate the amount of requested memory).");
             }
 
-            return Utilities.UnsafeAsciiBytesToString(buffer, 0, buffer.Length);
+            return Utilities.UnsafeAsciiBytesToString(buffer);
         }
 
         /// <summary>Derives a secret key of any size from a password and a salt.</summary>

--- a/src/Sodium.Core/PasswordHash.cs
+++ b/src/Sodium.Core/PasswordHash.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 
 using Sodium.Exceptions;
@@ -253,7 +253,7 @@ namespace Sodium
                 throw new OutOfMemoryException("Internal error, hash failed (usually because the operating system refused to allocate the amount of requested memory).");
             }
 
-            return Encoding.UTF8.GetString(buffer);
+            return Utilities.UnsafeAsciiBytesToString(buffer, 0, buffer.Length);
         }
 
         /// <summary>Verifies that a hash generated with ArgonHashString matches the supplied password.</summary>
@@ -330,7 +330,7 @@ namespace Sodium
                 throw new OutOfMemoryException("Internal error, hash failed (usually because the operating system refused to allocate the amount of requested memory).");
             }
 
-            return Encoding.UTF8.GetString(buffer);
+            return Utilities.UnsafeAsciiBytesToString(buffer, 0, buffer.Length);
         }
 
         /// <summary>Derives a secret key of any size from a password and a salt.</summary>

--- a/src/Sodium.Core/Utilities.cs
+++ b/src/Sodium.Core/Utilities.cs
@@ -237,15 +237,27 @@ namespace Sodium
             return ret == 0;
         }
 
-        internal static string UnsafeAsciiBytesToString(byte[] buffer, int offset, int length)
+        internal static string UnsafeAsciiBytesToString(byte[] buffer)
         {
+#if NETSTANDARD1_6
+            var handle = GCHandle.Alloc(buffer, GCHandleType.Pinned);
+            try
+            {
+                return Marshal.PtrToStringAnsi(handle.AddrOfPinnedObject());
+            }
+            finally
+            {
+                handle.Free();
+            }
+#else
             unsafe
             {
                 fixed (byte* ascii = buffer)
                 {
-                    return new string((sbyte*)ascii, offset, length);
+                    return new string((sbyte*)ascii, 0, buffer.Length);
                 }
             }
+#endif
         }
     }
 }

--- a/src/Sodium.Core/Utilities.cs
+++ b/src/Sodium.Core/Utilities.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Runtime.InteropServices;
 using System.Text;
 
@@ -235,6 +235,17 @@ namespace Sodium
             var ret = SodiumLibrary.sodium_compare(a, b, a.Length);
 
             return ret == 0;
+        }
+
+        internal static string UnsafeAsciiBytesToString(byte[] buffer, int offset, int length)
+        {
+            unsafe
+            {
+                fixed (byte* ascii = buffer)
+                {
+                    return new string((sbyte*)ascii, offset, length);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The UTF-8 encoding doesn't handle null-terminated strings. Fixes #46.