### PR TITLE
SecretAeadChaCha20Poly1305IETF NONCE Bytes

### DIFF
--- a/src/Sodium.Core/SecretAeadChaCha20Poly1305IETF.cs
+++ b/src/Sodium.Core/SecretAeadChaCha20Poly1305IETF.cs
@@ -10,7 +10,7 @@ namespace Sodium
     public static class SecretAeadChaCha20Poly1305IETF
     {
         private const int KEYBYTES = 32;
-        private const int NPUBBYTES = 8;
+        private const int NPUBBYTES = 12;
         private const int ABYTES = 16;
 
         //TODO: we could implement a method which increments the nonce.


### PR DESCRIPTION
As described in documentation https://libsodium.gitbook.io/doc/secret-key_cryptography/aead/chacha20-poly1305/ietf_chacha20-poly1305_construction#constants "- The nonce size is the only constant that differs between the original variant and the IETF variant.". Nonce size constant for IETF should be 12 bytes. You can see it in https://github.com/jedisct1/libsodium/blob/6d566070b48efd2fa099bbe9822914455150aba9/src/libsodium/include/sodium/crypto_aead_chacha20poly1305.h.